### PR TITLE
Fix bug of ControlId: 1.23, for non password user

### DIFF
--- a/aws_cis_foundation_framework/aws-cis-foundation-benchmark-checklist.py
+++ b/aws_cis_foundation_framework/aws-cis-foundation-benchmark-checklist.py
@@ -727,7 +727,7 @@ def control_1_23_no_active_initial_access_keys_with_iam_user(credreport):
     scored = False
     offenders = []
     for n, _ in enumerate(credreport):
-        if (credreport[n]['access_key_1_active'] or credreport[n]['access_key_2_active'] == 'true') and n > 0:
+        if (credreport[n]['access_key_1_active'] or credreport[n]['access_key_2_active'] == 'true') and n > 0 and credreport[n]['password_enabled'] == 'true':
             response = IAM_CLIENT.list_access_keys(
                 UserName=str(credreport[n]['user'])
             )


### PR DESCRIPTION
Fix bug of Control ID: 1.23.

Definition of Control ID: 1.23 is "Do not setup access keys during initial user setup for all IAM users that have a console password"

Add new conditional to exclude the IAM users which don't have console password.